### PR TITLE
164796910 Adds Comment Edit History feature

### DIFF
--- a/src/controllers/comment.js
+++ b/src/controllers/comment.js
@@ -1,13 +1,13 @@
-import { Comment } from '../models';
-import { errorResponseFormat } from '../utils/index';
+import { Comment, CommentEditHistory } from '../models';
+import { errorResponseFormat, sendResponse } from '../utils/index';
+import { getLastComment, commentIsTheSame } from '../utils/comment';
 /**
-   * @method comment
-   * @description enable authenticated users to comment on existing article
-   * @param {object} req - The Request Object
-   * @param {object} res - The Response Object
-   * @returns {object} - JSON new comment response object
-   */
-
+ * @function addComment
+ * @description enable authenticated users to comment on existing article
+ * @param {object} req - The Request Object
+ * @param {object} res - The Response Object
+ * @returns {object} - JSON new comment response object
+*/
 export const addComment = async (req, res) => {
   const { articleId } = req.params;
   const { body } = req;
@@ -29,9 +29,76 @@ export const addComment = async (req, res) => {
     }
     if (error.parent.file === 'uuid.c') {
       return res.status(404).json(errorResponseFormat({
-        status: 'fail',
+        status: 'error',
         message: 'invalid id of type UUID'
       }));
     }
+  }
+};
+
+/**
+ * @description Updates a comment
+ * @function updateComment
+ * @param {object} req request object
+ * @param {object} res response object
+ * @returns {Response} Returns a server success or error response
+ */
+export const editComment = async (req, res) => {
+  try {
+    const { articleId, commentId } = req.params;
+    const { body } = req.body;
+    const criteria = { articleId, id: commentId };
+    const comment = await Comment.findOne({ where: criteria });
+    if (!comment) return sendResponse(res, 404, { responseType: 'fail', data: 'Comment does not exist' });
+    if (comment.userId !== req.user.id) {
+      return sendResponse(res, 422, { responseType: 'fail', data: 'You can only edit your comment' });
+    }
+    const lastComment = await getLastComment(comment.id);
+    // track comment edit history
+    const commentIsSame = commentIsTheSame(lastComment, body);
+    if (commentIsSame) {
+      await CommentEditHistory.create({ commentId, commentBody: comment.body });
+    }
+    const updatedComment = await comment.update({
+      body: body || comment.body
+    }, { where: criteria }, { returning: true });
+    return sendResponse(res, 200, { responseType: 'success', data: updatedComment });
+  } catch (error) {
+    return sendResponse(res, 500, { responseType: 'error', data: 'internal server error occurred' });
+  }
+};
+
+/**
+ * @description Retrieves all comments
+ * @function getAllComments
+ * @param {object} req request object
+ * @param {object} res response object
+ * @returns {Response} Returns a server success or error response
+ */
+export const getAllComments = async (req, res) => {
+  try {
+    const { articleId } = req.params;
+    const comments = await Comment.findAll({ where: { articleId } });
+    return sendResponse(res, 200, { responseType: 'success', data: comments });
+  } catch (error) {
+    return sendResponse(res, 500, { responseType: 'error', data: 'internal server error occurred' });
+  }
+};
+
+/**
+ * @description Retrieves a single comment
+ * @function getAComment
+ * @param {object} req request object
+ * @param {object} res response object
+ * @returns {Response} Returns a server success or error response
+ */
+export const getAComment = async (req, res) => {
+  try {
+    const { commentId } = req.params;
+    const comment = await Comment.findByPk(commentId);
+    const editHistory = await CommentEditHistory.findAll({ where: { commentId: comment.id } });
+    return sendResponse(res, 200, { responseType: 'success', data: { comment, history: editHistory } });
+  } catch (error) {
+    return res.status(500).json({ status: 'error', message: 'internal server error occurred' });
   }
 };

--- a/src/middlewares/index.js
+++ b/src/middlewares/index.js
@@ -1,0 +1,23 @@
+/* eslint-disable no-restricted-syntax */
+
+/**
+ * @description Trims request body
+ * @function trimBody
+ * @param {object} req Request object
+ * @param {object} res Response object
+ * @param {function} next next middleware function
+ * @returns {void}
+ */
+export const trimBody = (req, res, next) => {
+  const trimmedBody = {};
+  for (const key in req.body) {
+    if (Object.prototype.hasOwnProperty.call(req.body, key)) {
+      const value = req.body[key];
+      trimmedBody[key] = typeof value === 'string' ? value.trim() : value;
+    }
+  }
+  req.body = { ...trimmedBody };
+  next();
+};
+
+export default { trimBody };

--- a/src/migrations/20190421215906-create-comment-edit-history.js
+++ b/src/migrations/20190421215906-create-comment-edit-history.js
@@ -1,0 +1,32 @@
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.createTable(
+    'comment-edit-history', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4
+      },
+      commentId: {
+        type: Sequelize.UUID,
+        references: {
+          model: 'comments',
+          key: 'id',
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE'
+        }
+      },
+      commentBody: {
+        type: Sequelize.TEXT
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    }),
+  down: queryInterface => queryInterface.dropTable('comment-edit-history')
+};

--- a/src/models/comment_edit_history.js
+++ b/src/models/comment_edit_history.js
@@ -1,0 +1,33 @@
+
+
+export default (sequelize, DataTypes) => {
+  const CommentEditHistory = sequelize.define(
+    'CommentEditHistory', {
+      id: {
+        type: DataTypes.UUID,
+        primaryKey: true,
+        allowNull: false,
+        defaultValue: DataTypes.UUIDV4,
+      },
+      commentId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+      },
+      commentBody: {
+        type: DataTypes.TEXT,
+        allowNull: false
+      }
+    },
+    {
+      tableName: 'comment-edit-history',
+      freetableName: true
+    });
+  CommentEditHistory.associate = (models) => {
+    CommentEditHistory.belongsTo(models.Comment, {
+      foriegnKey: 'commentId',
+      onDelete: 'CASCADE',
+      as: 'comment'
+    });
+  };
+  return CommentEditHistory;
+};

--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -12,7 +12,7 @@ import {
   rateArticle,
   publishArticle
 } from '../controllers/article';
-import { addComment } from '../controllers/comment';
+import { addComment, editComment, getAllComments, getAComment } from '../controllers/comment';
 import checkFields from '../middlewares/auth/loginValidator';
 import Auth from '../middlewares/authenticator';
 import socialRedirect from '../controllers/authentication/socialRedirect';
@@ -45,6 +45,7 @@ import getAuthors from '../controllers/authors';
 import highlightArticle from '../controllers/highlight';
 import { forgotPassword, resetPassword } from '../controllers/authentication/passwordReset';
 import resetFieldValidation from '../middlewares/auth/resetPassword';
+import { trimBody } from '../middlewares';
 
 
 const router = Router();
@@ -124,7 +125,16 @@ router.get(
 
 router.get('/auth/linkedin/callback', linkedinCallback);
 router.get('/auth/linkedin', linkedinUser);
-router.post('/articles/:articleId/comments', Auth.authenticateUser, commentValidation, addComment);
+
+router
+  .route('/articles/:articleId/comments')
+  .post(Auth.authenticateUser, commentValidation, addComment)
+  .get(Auth.authenticateUser, getAllComments);
+
+router
+  .route('/articles/:articleId/comments/:commentId')
+  .get(Auth.authenticateUser, getAComment)
+  .put(Auth.authenticateUser, trimBody, commentValidation, editComment);
 
 // Route for user following and unfollowing
 router.post('/followers/:id/follow', checkParam, Auth.authenticateUser, followAndUnfollowUser);

--- a/src/seeders/20190402103723-comment.js
+++ b/src/seeders/20190402103723-comment.js
@@ -20,6 +20,15 @@ export default {
         createdAt: new Date(),
         updatedAt: new Date(),
       },
+      {
+        id: '979eaa2e-5b8f-4103-8192-4639afae2bb7',
+        userId: '7e824eba-2a9e-4933-affa-6a3da937e47c',
+        articleId: '979eaa2e-5b8f-4103-8192-4639afae2ba7',
+        body:
+            'Put simply, JSend is a specification that lays down some rules for how JSON responses from web servers should be formatted. JSend focuses on application-level (as opposed to protocol- or transport-level) messaging which makes it ideal for use in REST-style applications and APIs.',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
     ],
     {}
   ),

--- a/src/seeders/20190421221728-comment-edit-history.js
+++ b/src/seeders/20190421221728-comment-edit-history.js
@@ -1,0 +1,19 @@
+export default {
+  up: queryInterface => queryInterface.bulkInsert('comment-edit-history', [
+    {
+      id: '979eaa2e-5b8f-4103-8192-4639afae2bb0',
+      commentId: '979eaa2e-5b8f-4103-8192-4639afae2bb9',
+      commentBody: 'Put simply, JSend is a specification that lays down some rules for how JSON responses from web servers should be formatted. JSend focuses on application-level (as opposed to protocol- or transport-level) messaging which makes it ideal for use in REST-style applications and APIs.',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: '979eaa2e-5b8f-4103-8192-4639afae2bb1',
+      commentId: '979eaa2e-5b8f-4103-8192-4639afae2bb9',
+      commentBody: 'Put simply, JSend focuses on application-level (as opposed to protocol- or transport-level) messaging which makes it ideal for use in REST-style applications and APIs.',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }
+  ], {}),
+  down: queryInterface => queryInterface.bulkDelete('comment-edit-history', null, {})
+};

--- a/src/utils/comment.js
+++ b/src/utils/comment.js
@@ -1,4 +1,5 @@
 import Validator from 'validatorjs';
+import { CommentEditHistory } from '../models';
 
 /**
  * @description This is the method for validating comment before inserting
@@ -8,12 +9,26 @@ import Validator from 'validatorjs';
 
 export const validateComment = (payload) => {
   const rules = {
-    body: 'required',
+    body: 'required|string',
   };
 
   const errorMessages = {
-    'required.body': 'comment body is required'
+    'required.body': 'comment body is required',
+    'string.body': 'comment must be a string',
 
   };
   return new Validator(payload, rules, errorMessages);
 };
+
+export const getLastComment = async (commentId) => {
+  try {
+    const histories = await CommentEditHistory.findAll({ where: { commentId }, raw: true });
+    const lastHistory = histories[histories.length - 1];
+    console.log(lastHistory);
+    return lastHistory ? lastHistory.commentBody : '';
+  } catch (error) {
+    throw error;
+  }
+};
+
+export const commentIsTheSame = (oldComment, newComment) => oldComment !== newComment;

--- a/src/utils/comment.js
+++ b/src/utils/comment.js
@@ -24,7 +24,6 @@ export const getLastComment = async (commentId) => {
   try {
     const histories = await CommentEditHistory.findAll({ where: { commentId }, raw: true });
     const lastHistory = histories[histories.length - 1];
-    console.log(lastHistory);
     return lastHistory ? lastHistory.commentBody : '';
   } catch (error) {
     throw error;

--- a/tests/integration/comment.test.js
+++ b/tests/integration/comment.test.js
@@ -2,45 +2,192 @@ import 'chai/register-should';
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import { startServer } from '../../src/server';
-import { articleId } from '../mock/bookmark';
-import { comment } from '../mock/comment';
+import { articleId, invalidArticleUUID } from '../mock/bookmark';
+import commentMock, { comment } from '../mock/comment';
 import { JWT_TOKEN } from '../mock/user';
+import Auth from '../../src/middlewares/authenticator';
 
 const { assert } = chai;
 let app = null;
 let agent = null;
 
+const { mockCommentIds, mockCommentArticleIds } = commentMock;
+
+const [validCommentId1] = mockCommentIds.valid;
+const [invalidCommentId1] = mockCommentIds.invalid;
+const [validArticleId1, validArticleId2] = mockCommentArticleIds.valid;
+
 chai.use(chaiHttp);
 
-describe('POST comment on article', () => {
+describe('Comment API test', () => {
   beforeEach(async () => {
     app = await startServer(5500);
     agent = chai.request(app);
   });
+  describe('POST comment on article', () => {
+    it('should add a comment successfully', (done) => {
+      agent.post(`/api/v1/articles/${articleId}/comments`)
+        .set('Authorization', JWT_TOKEN)
+        .send(comment)
+        .end((_err, res) => {
+          const { status, body } = res;
+          assert.equal(status, 201);
+          assert.isObject(body);
+          assert.equal(body.status, 'success');
+          assert.property(body, 'data');
+          done();
+        });
+    });
 
-  it('comment added successfully', (done) => {
-    agent.post(`/api/v1/articles/${articleId}/comments`)
-      .set('Authorization', JWT_TOKEN)
-      .send(comment)
-      .end((_err, res) => {
-        const { status, body } = res;
-        assert.equal(status, 201);
-        assert.isObject(body);
-        assert.equal(body.status, 'success');
-        assert.property(body, 'data');
-        done();
-      });
+    it('should fail when an empty or no body is supplied', (done) => {
+      agent.post(`/api/v1/articles/${articleId}/comments`)
+        .set('Authorization', JWT_TOKEN)
+        .end((_err, res) => {
+          const { status, body } = res;
+          assert.equal(status, 400);
+          assert.isObject(body);
+          assert.equal(body.status, 'fail');
+          done();
+        });
+    });
   });
 
-  it('empty body content  ', (done) => {
-    agent.post(`/api/v1/articles/${articleId}/comments`)
-      .set('Authorization', JWT_TOKEN)
-      .end((_err, res) => {
-        const { status, body } = res;
-        assert.equal(status, 400);
-        assert.isObject(body);
-        assert.equal(body.status, 'fail');
-        done();
+  describe('PUT /articles/:articleId/comments/:commentId', () => {
+    describe('handle valid request', () => {
+      it('should update an article successfully', (done) => {
+        agent.put(`/api/v1/articles/${validArticleId1}/comments/${validCommentId1}`)
+          .set('Authorization', JWT_TOKEN)
+          .send({ body: 'new comment' })
+          .end((err, res) => {
+            if (err) return done(err);
+            const { status, body } = res;
+            status.should.equal(200);
+            body.status.should.equal('success');
+            body.data.should.be.an('object');
+            body.data.body.should.equal('new comment');
+            done();
+          });
       });
+
+      it('should not update a comment if the previous comment and the new comment is similar', (done) => {
+        agent
+          .get(`/api/v1/articles/${validArticleId1}/comments/${validCommentId1}`)
+          .set('Authorization', JWT_TOKEN)
+          .send({ body: 'new comment' })
+          .end((err, res) => {
+            if (err) return done(err);
+            const { status, body } = res;
+            status.should.equal(200);
+            body.status.should.equal('success');
+            body.data.history.length.should.equal(3);
+            done();
+          });
+      });
+    });
+    describe('handle invalid request', () => {
+      it('should return  a 404 error for a comment that doesn\'t exist for an article', (done) => {
+        agent
+          .put(`/api/v1/articles/${validArticleId2}/comments/${validCommentId1}`)
+          .set('Authorization', JWT_TOKEN)
+          .send({ body: 'new comment' })
+          .end((err, res) => {
+            if (err) return done(err);
+            const { status, body } = res;
+            status.should.equal(404);
+            body.status.should.equal('fail');
+            body.data.should.equal('Comment does not exist');
+            done();
+          });
+      });
+      // skipped due to bug in running the tests
+      it('should return a 404 error if comment is not owned by user', (done) => {
+        const token = Auth.generateToken({ id: '146fa633-98dd-467f-9e4d-48eac3ee14e4' });
+        agent
+          .put(`/api/v1/articles/${validArticleId1}/comments/${validCommentId1}`)
+          .set('Authorization', token)
+          .send({ body: 'new comment' })
+          .end((err, res) => {
+            if (err) return done(err);
+            const { status, body } = res;
+            status.should.equal(422);
+            body.status.should.equal('fail');
+            body.data.should.equal('You can only edit your comment');
+            done();
+          });
+      });
+    });
+    it('should return a server error for an invalid comment id', (done) => {
+      agent
+        .put(`/api/v1/articles/${validArticleId2}/comments/${invalidCommentId1}`)
+        .set('Authorization', JWT_TOKEN)
+        .send({ body: 'new comment' })
+        .end((err, res) => {
+          if (err) return done(err);
+          const { status, body } = res;
+          status.should.equal(500);
+          body.status.should.equal('error');
+          done();
+        });
+    });
+  });
+
+  describe('GET /articles/:articleId/comments', () => {
+    it('should return all comments', (done) => {
+      agent
+        .get(`/api/v1/articles/${validArticleId1}/comments`)
+        .set('Authorization', JWT_TOKEN)
+        .end((err, res) => {
+          if (err) return done(err);
+          const { status, body } = res;
+          status.should.equal(200);
+          body.status.should.equal('success');
+          body.data.should.be.an('array');
+          done();
+        });
+    });
+
+    it('should return an error if supplied wrong article id', (done) => {
+      agent
+        .get(`/api/v1/articles/${invalidArticleUUID}/comments`)
+        .set('Authorization', JWT_TOKEN)
+        .end((err, res) => {
+          if (err) return done(err);
+          const { status, body } = res;
+          status.should.equal(500);
+          body.status.should.equal('error');
+          done();
+        });
+    });
+  });
+
+  describe('GET /articles/:articleId/comments/:commentId', () => {
+    it('should return a single comment', (done) => {
+      agent
+        .get(`/api/v1/articles/${validArticleId1}/comments/${validCommentId1}`)
+        .set('Authorization', JWT_TOKEN)
+        .end((err, res) => {
+          if (err) return done(err);
+          const { status, body } = res;
+          status.should.equal(200);
+          body.status.should.equal('success');
+          body.data.should.have.property('comment');
+          body.data.should.have.property('history');
+          body.data.history.should.be.an('array');
+          done();
+        });
+    });
+
+    it('should return an error if supplied wrong comment id', (done) => {
+      agent
+        .get(`/api/v1/articles/${validArticleId1}/comments/${invalidCommentId1}`)
+        .set('Authorization', JWT_TOKEN)
+        .end((err, res) => {
+          if (err) return done(err);
+          const { status, body } = res;
+          status.should.equal(500);
+          body.status.should.equal('error');
+          done();
+        });
+    });
   });
 });

--- a/tests/mock/comment.js
+++ b/tests/mock/comment.js
@@ -13,3 +13,17 @@ export const invalidComment = {
 export const invalidarticleUUID = {
   articleId: '1839374c-53ea-438c-xxxxxxxxx',
 };
+
+export default {
+  comment,
+  uncompleteCommentBody,
+  invalidComment,
+  invalidarticleUUID,
+  mockCommentIds: {
+    valid: ['979eaa2e-5b8f-4103-8192-4639afae2bb9'],
+    invalid: ['979eaa2e-5b8f-4103-8192-4639afae2bb']
+  },
+  mockCommentArticleIds: {
+    valid: ['979eaa2e-5b8f-4103-8192-4639afae2ba8', '979eaa2e-5b8f-4103-8192-4639afae2ba7']
+  }
+};

--- a/tests/unit/article.test.js
+++ b/tests/unit/article.test.js
@@ -71,9 +71,5 @@ describe('Article Utils test', () => {
         });
       });
     });
-
-    describe('validateArticleReport()', () => {
-
-    });
   });
 });

--- a/tests/unit/middlewares.test.js
+++ b/tests/unit/middlewares.test.js
@@ -1,0 +1,29 @@
+import 'chai/register-should';
+import sinon from 'sinon';
+import { trimBody } from '../../src/middlewares';
+
+describe('Middlewares tests', () => {
+  describe('trimBody', () => {
+    it('should trim request body', () => {
+      const req = {
+        body: { name: 'Micah   ', cohort: '    46' }
+      };
+      const res = {};
+      const next = sinon.spy();
+      trimBody(req, res, next);
+      req.body.should.deep.equal({ name: 'Micah', cohort: '46' });
+      next.called.should.equal(true);
+    });
+
+    it('should trim request body', () => {
+      const req = {
+        body: { name: '   Micah ', seenGot: true }
+      };
+      const res = {};
+      const next = sinon.spy();
+      trimBody(req, res, next);
+      req.body.should.deep.equal({ name: 'Micah', seenGot: true });
+      next.called.should.equal(true);
+    });
+  });
+});

--- a/tests/unit/util.test.js
+++ b/tests/unit/util.test.js
@@ -83,7 +83,7 @@ describe('Util test', () => {
       });
     });
 
-    it('should return error 2', () => {
+    it('should return error', () => {
       handleDBErrors(dbError, { req, Sequelize }, (message) => {
         message.should.equal('Database error: table "articles" is not present');
       });


### PR DESCRIPTION
#### Description
Add a comment edit history feature to facilitate the retrieval of a comment's edit history
#### Type of change
New feature (non-breaking change that adds functionality)
#### How Has This Been Tested?
- [x] unit tests
- [x] integration tests
#### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] I have added tests that prove my fix is effective or that my feature works
#### Screenshots
- Postman:
(no edits yet)
<img width="627" alt="comment edit history - empty" src="https://user-images.githubusercontent.com/15838829/56659733-ca32d500-6695-11e9-8b19-dc998aa6605a.png">
(new edits has been made)
<img width="627" alt="comment-edit-history" src="https://user-images.githubusercontent.com/15838829/56659855-0cf4ad00-6696-11e9-8935-f11b4640d4a8.png">

- Flowchart
![comment-history](https://user-images.githubusercontent.com/15838829/56528442-17546100-6547-11e9-925a-74fac64666a9.jpg)

#### PT
[164796910](https://www.pivotaltracker.com/story/show/164796910)